### PR TITLE
fixed relative imports

### DIFF
--- a/packages/solidifier/index.js
+++ b/packages/solidifier/index.js
@@ -30,7 +30,7 @@ const getFileContents = fileObject => (
 		if (fileObject.textContents) {
 			return resolve(fileObject.textContents);
 		} else {
-			const reader = new FileReader();
+			const reader = new window.FileReader();
 			reader.onload = () => resolve(reader.result);
 			reader.onerror = () => reject(reader.error);
 


### PR DESCRIPTION
Currently flatenning solidity files that has an import to a relative file from a library in `node_modules` will fail.

For example, when flattening `openzeppelin-solidity-2.3.0/contracts/token/ERC20/SafeERC20.sol` (in node_modules) `SafeERC20.sol` imports from `./ERC20.sol`, the flattener assumes that the file `ERC20.sol` is in `contracts/ERC20.sol` (when it should be in `openzeppelin-solidity-2.3.0/contracts/token/ERC20/ERC20.sol`) and will throw an error.

This PR fixes the issue mentioned